### PR TITLE
Add translation continuation flow

### DIFF
--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -15,6 +15,8 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [scraperProvider, setScraperProvider] =
 		useLocalStorage<ScraperProvider>("scraperProvider", "jina");
 	const [ignoreCache, setIgnoreCache] = useState(false);
+	const [continuedCompletionPrefix, setContinuedCompletionPrefix] =
+		useState("");
 
 	useEffect(() => {
 		// Update dark mode class on html element
@@ -27,6 +29,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 		error,
 		complete,
 		input,
+		setCompletion,
 		setInput,
 		handleInputChange,
 		handleSubmit,
@@ -45,6 +48,8 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 
 	console.error({ error });
 
+	const displayedCompletion = `${continuedCompletionPrefix}${completion}`;
+
 	// useEffect(() => {
 	//   if (input) {
 	//     setTranslateUrl(input);
@@ -54,6 +59,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 
 	async function goToChapter(direction: "next" | "previous") {
 		stop();
+		setContinuedCompletionPrefix("");
 
 		// Replace chapter number in url
 		const newUrl =
@@ -76,6 +82,26 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 
 		// Scroll to top of the page
 		window.scrollTo({ top: 0, behavior: "smooth" });
+	}
+
+	function continueTranslation() {
+		const currentCompletion = displayedCompletion;
+
+		if (isLoading || !currentCompletion.trim()) {
+			return;
+		}
+
+		setContinuedCompletionPrefix(currentCompletion);
+		setCompletion("");
+		complete(input, {
+			body: {
+				ignoreCache: true,
+				mode,
+				model,
+				scraperProvider,
+				continueFrom: currentCompletion,
+			},
+		});
 	}
 
 	const fontSizeClasses = [
@@ -102,7 +128,13 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	return (
 		<div className="w-full lg:max-w-6xl mx-auto p-4 min-h-screen bg-gray-100 dark:bg-gray-900">
 			<div className="bg-white dark:bg-gray-800 rounded-lg shadow flex flex-col h-full">
-				<form onSubmit={handleSubmit} className="p-4">
+				<form
+					onSubmit={(event) => {
+						setContinuedCompletionPrefix("");
+						handleSubmit(event);
+					}}
+					className="p-4"
+				>
 					<div className="flex gap-2">
 						<textarea
 							rows={3}
@@ -384,7 +416,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 				>
 					{error && <div className="text-red-500">{error.message}</div>}
 					<div className="w-full break-words whitespace-pre-line rounded-lg">
-						{completion}
+						{displayedCompletion}
 					</div>
 					{isLoading && (
 						<div className="flex justify-center">
@@ -421,6 +453,14 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 						onClick={() => goToChapter("previous")}
 					>
 						Previous Chapter
+					</button>
+					<button
+						type="button"
+						className="bg-emerald-500 text-white px-4 py-2 rounded-lg hover:bg-emerald-600 transition disabled:cursor-not-allowed disabled:opacity-50"
+						onClick={continueTranslation}
+						disabled={isLoading || !displayedCompletion.trim()}
+					>
+						Continue
 					</button>
 					<button
 						type="button"

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -49,6 +49,11 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	console.error({ error });
 
 	const displayedCompletion = `${continuedCompletionPrefix}${completion}`;
+	const trimmedCompletion = displayedCompletion.trim();
+	const canContinueTranslation =
+		!isLoading &&
+		trimmedCompletion.length > 0 &&
+		!trimmedCompletion.endsWith("</translation>");
 
 	// useEffect(() => {
 	//   if (input) {
@@ -87,7 +92,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	function continueTranslation() {
 		const currentCompletion = displayedCompletion;
 
-		if (isLoading || !currentCompletion.trim()) {
+		if (!canContinueTranslation) {
 			return;
 		}
 
@@ -454,14 +459,15 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 					>
 						Previous Chapter
 					</button>
-					<button
-						type="button"
-						className="bg-emerald-500 text-white px-4 py-2 rounded-lg hover:bg-emerald-600 transition disabled:cursor-not-allowed disabled:opacity-50"
-						onClick={continueTranslation}
-						disabled={isLoading || !displayedCompletion.trim()}
-					>
-						Continue
-					</button>
+					{canContinueTranslation && (
+						<button
+							type="button"
+							className="bg-emerald-500 text-white px-4 py-2 rounded-lg hover:bg-emerald-600 transition"
+							onClick={continueTranslation}
+						>
+							Continue
+						</button>
+					)}
 					<button
 						type="button"
 						className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -109,24 +109,23 @@ async function getContinuationStreamResult(
 		messages: [
 			{
 				role: "system",
-				content: `${PROMPT_MAP[mode]}
-
-The previous response was cut off. Continue the same translation from exactly where it stopped.
-Return only the missing continuation text. Do not repeat any text that already appears in the existing translation, and do not add explanations or notes.`,
+				content: PROMPT_MAP[mode],
 			},
 			{
 				role: "user",
 				content: `Here are the original work you will be working with:
 <original>
 ${html}
-</original>
-
-Here is the existing translation that was cut off:
-<existing_translation>
-${continueFrom}
-</existing_translation>
-
-Continue the translation from exactly after the existing translation above.`,
+</original>`,
+			},
+			{
+				role: "assistant",
+				content: continueFrom,
+			},
+			{
+				role: "user",
+				content:
+					"Your previous translation was cut off. Continue from exactly where it stopped. Return only the missing continuation text, without repeating any text already shown and without adding explanations or notes.",
 			},
 		],
 		...(model === "anthropic" && {

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -91,6 +91,79 @@ ${html}
 	return result;
 }
 
+async function getContinuationStreamResult(
+	url: string,
+	mode: Mode,
+	model: ModelType = "google",
+	scraperProvider: ScraperProvider = "jina",
+	continueFrom: string,
+): Promise<Result> {
+	const html = await crawl(url, scraperProvider);
+
+	const PROMPT_MAP = await getPromptMap();
+
+	console.time("continueStreamText");
+	const result = streamText({
+		model: MODEL_MAP[model],
+		maxOutputTokens: MODEL_MAX_TOKENS[model],
+		messages: [
+			{
+				role: "system",
+				content: `${PROMPT_MAP[mode]}
+
+The previous response was cut off. Continue the same translation from exactly where it stopped.
+Return only the missing continuation text. Do not repeat any text that already appears in the existing translation, and do not add explanations or notes.`,
+			},
+			{
+				role: "user",
+				content: `Here are the original work you will be working with:
+<original>
+${html}
+</original>
+
+Here is the existing translation that was cut off:
+<existing_translation>
+${continueFrom}
+</existing_translation>
+
+Continue the translation from exactly after the existing translation above.`,
+			},
+		],
+		...(model === "anthropic" && {
+			providerOptions: {
+				anthropic: {
+					thinking: { type: "enabled", budgetTokens: 2048 },
+				} satisfies AnthropicProviderOptions,
+			},
+		}),
+		...((model === "google" || model === "google_flash") && {
+			providerOptions: {
+				google: {
+					safetySettings: [
+						{ category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE" },
+						{
+							category: "HARM_CATEGORY_DANGEROUS_CONTENT",
+							threshold: "BLOCK_NONE",
+						},
+						{ category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+						{
+							category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+							threshold: "BLOCK_NONE",
+						},
+						{
+							category: "HARM_CATEGORY_CIVIC_INTEGRITY",
+							threshold: "BLOCK_NONE",
+						},
+					],
+				} satisfies GoogleGenerativeAIProviderOptions,
+			},
+		}),
+	});
+	console.timeEnd("continueStreamText");
+
+	return result;
+}
+
 async function getStreamFromCache(
 	url: string,
 	mode: Mode,
@@ -155,14 +228,30 @@ export const POST: APIRoute = async ({ request }) => {
 		mode = "wuxia",
 		model = "google",
 		scraperProvider = "jina",
+		continueFrom,
 	}: {
 		prompt: string;
 		ignoreCache: boolean;
 		mode: Mode;
 		model: ModelType;
 		scraperProvider: ScraperProvider;
+		continueFrom?: string;
 	} = await request.json();
 	const url = prompt;
+
+	if (continueFrom?.trim()) {
+		const result = await getContinuationStreamResult(
+			url,
+			mode,
+			model,
+			scraperProvider,
+			continueFrom,
+		);
+
+		return (
+			result?.toTextStreamResponse() ?? new Response(null, { status: 501 })
+		);
+	}
 
 	const result = await getStreamFromCache(
 		url,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Continue button that starts a continuation request from the currently displayed translation.
- Preserve the existing output while streaming the continuation suffix after it.
- Hide Continue while streaming and once the trimmed output ends with `</translation>`.
- Handle continuation requests separately from the normal chapter translation cache and skip next-chapter prefetch for them.
- Build continuation requests from the original system/user messages, the cut-off translation as an assistant message, and a final user instruction to output only from the cutoff.

## Verification
- `npm run lint`
- `npm test -- --run`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fd9ca6d-9820-4753-9881-e34070f99054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fd9ca6d-9820-4753-9881-e34070f99054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

