### PR TITLE
Switch Kimi option to Qwen thinking model

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -37,7 +37,7 @@ export const googleModel = google("gemini-3.1-pro-preview");
 
 export const googleFlashModel = google("gemini-3.5-flash");
 
-export const nanogpt = openaiCompatible("moonshotai/kimi-k2-thinking-original");
+export const qwenMaxThinkingModel = openaiCompatible("qwen3.7-max:thinking");
 
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
@@ -47,7 +47,7 @@ export const deepseekModel = deepseek("deepseek-v4-pro");
 export const MODEL_MAP = {
 	google: googleModel,
 	google_flash: googleFlashModel,
-	nanogpt: nanogpt,
+	nanogpt: qwenMaxThinkingModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
 } as const;

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -362,7 +362,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									htmlFor="nanogpt_model"
 									className="text-gray-700 dark:text-gray-300"
 								>
-									NanoGPT (Kimi K2)
+									Qwen 3.7 Max Thinking
 								</label>
 							</div>
 						</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Point the existing NanoGPT-compatible model option at `qwen3.7-max:thinking`
- Update the translate UI label from Kimi K2 to Qwen 3.7 Max Thinking

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b1ee49f-e853-491b-9df1-f9e97837b6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b1ee49f-e853-491b-9df1-f9e97837b6e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

