### PR TITLE
Increase model token limits

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -54,5 +54,5 @@ export const MODEL_MAP = {
 
 export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {
 	anthropic: 32000,
-	deepseek: 8192,
+	deepseek: 32000,
 };

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -59,7 +59,7 @@ ${html}
 		...(model === "anthropic" && {
 			providerOptions: {
 				anthropic: {
-					thinking: { type: "enabled", budgetTokens: 2048 },
+					thinking: { type: "enabled", budgetTokens: 4096 },
 				} satisfies AnthropicProviderOptions,
 			},
 		}),
@@ -131,7 +131,7 @@ ${html}
 		...(model === "anthropic" && {
 			providerOptions: {
 				anthropic: {
-					thinking: { type: "enabled", budgetTokens: 2048 },
+					thinking: { type: "enabled", budgetTokens: 4096 },
 				} satisfies AnthropicProviderOptions,
 			},
 		}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Increase DeepSeek max output tokens to 32000
- Increase Anthropic thinking budget tokens to 4096 in initial and continuation translation requests

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fb1d365-3edb-4154-b0a5-d357c5c5856d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb1d365-3edb-4154-b0a5-d357c5c5856d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

