### PR TITLE
Replace nano GPT model with MiMo thinking

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -37,7 +37,9 @@ export const googleModel = google("gemini-3.1-pro-preview");
 
 export const googleFlashModel = google("gemini-3.5-flash");
 
-export const qwenMaxThinkingModel = openaiCompatible("qwen3.7-max:thinking");
+export const mimoThinkingModel = openaiCompatible(
+	"xiaomi/mimo-v2.5-pro:thinking",
+);
 
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
@@ -47,7 +49,7 @@ export const deepseekModel = deepseek("deepseek-v4-pro");
 export const MODEL_MAP = {
 	google: googleModel,
 	google_flash: googleFlashModel,
-	nanogpt: qwenMaxThinkingModel,
+	nanogpt: mimoThinkingModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
 } as const;

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -362,7 +362,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									htmlFor="nanogpt_model"
 									className="text-gray-700 dark:text-gray-300"
 								>
-									xiaomi/mimo-v2.5-pro:thinking
+									Mimo V2.5 Pro
 								</label>
 							</div>
 						</div>

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -362,7 +362,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									htmlFor="nanogpt_model"
 									className="text-gray-700 dark:text-gray-300"
 								>
-									Qwen 3.7 Max Thinking
+									xiaomi/mimo-v2.5-pro:thinking
 								</label>
 							</div>
 						</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the nano GPT model ID with `xiaomi/mimo-v2.5-pro:thinking`
- Update the model selector label to show `Mimo V2.5 Pro`

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0495657-9470-4f40-a37b-f596f1dcafe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0495657-9470-4f40-a37b-f596f1dcafe1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

