### PR TITLE
Add GLM 5.2 model option

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -32,7 +32,7 @@ const google = createGoogleGenerativeAI({
 	apiKey: import.meta.env.GOOGLE_GENERATIVE_AI_KEY,
 });
 
-const openaiCompatible = createOpenAICompatible({
+const nanoGptOpenAICompatible = createOpenAICompatible({
 	name: "nano-gpt",
 	apiKey: import.meta.env.NANO_GPT_API_KEY,
 	baseURL: "https://nano-gpt.com/api/v1",
@@ -45,11 +45,11 @@ export const googleModel = google("gemini-3.1-pro-preview");
 
 export const googleFlashModel = google("gemini-3.5-flash");
 
-export const mimoThinkingModel = openaiCompatible(
+export const mimoThinkingModel = nanoGptOpenAICompatible(
 	NANO_GPT_MIMO_THINKING_SUBMODEL,
 );
 
-export const glmModel = openaiCompatible(NANO_GPT_GLM_SUBMODEL);
+export const glmModel = nanoGptOpenAICompatible(NANO_GPT_GLM_SUBMODEL);
 
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,13 +3,23 @@ import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
+export const NANO_GPT_MIMO_THINKING_SUBMODEL =
+	"xiaomi/mimo-v2.5-pro:thinking";
+export const NANO_GPT_GLM_SUBMODEL = "zai-org/glm-5.2";
+export const NANO_GPT_MIMO_THINKING_MODEL_TYPE =
+	`nanogpt|${NANO_GPT_MIMO_THINKING_SUBMODEL}` as const;
+export const NANO_GPT_GLM_MODEL_TYPE =
+	`nanogpt|${NANO_GPT_GLM_SUBMODEL}` as const;
+
 export type ModelType =
 	| "google"
 	| "google_flash"
 	| "anthropic"
 	| "deepseek"
-	| "nanogpt"
-	| "glm";
+	| typeof NANO_GPT_MIMO_THINKING_MODEL_TYPE
+	| typeof NANO_GPT_GLM_MODEL_TYPE;
+
+export type LegacyModelType = ModelType | "nanogpt" | "glm";
 
 export type ScraperProvider = "jina" | "firecrawl";
 
@@ -39,10 +49,10 @@ export const googleModel = google("gemini-3.1-pro-preview");
 export const googleFlashModel = google("gemini-3.5-flash");
 
 export const mimoThinkingModel = openaiCompatible(
-	"xiaomi/mimo-v2.5-pro:thinking",
+	NANO_GPT_MIMO_THINKING_SUBMODEL,
 );
 
-export const glmModel = openaiCompatible("zai-org/glm-5.2");
+export const glmModel = openaiCompatible(NANO_GPT_GLM_SUBMODEL);
 
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
@@ -52,8 +62,8 @@ export const deepseekModel = deepseek("deepseek-v4-pro");
 export const MODEL_MAP = {
 	google: googleModel,
 	google_flash: googleFlashModel,
-	nanogpt: mimoThinkingModel,
-	glm: glmModel,
+	[NANO_GPT_MIMO_THINKING_MODEL_TYPE]: mimoThinkingModel,
+	[NANO_GPT_GLM_MODEL_TYPE]: glmModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
 } as const;
@@ -62,3 +72,15 @@ export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {
 	anthropic: 128000,
 	deepseek: 32000,
 };
+
+export function normalizeModelType(model: LegacyModelType): ModelType {
+	if (model === "nanogpt") {
+		return NANO_GPT_MIMO_THINKING_MODEL_TYPE;
+	}
+
+	if (model === "glm") {
+		return NANO_GPT_GLM_MODEL_TYPE;
+	}
+
+	return model;
+}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,8 +3,7 @@ import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
-export const NANO_GPT_MIMO_THINKING_SUBMODEL =
-	"xiaomi/mimo-v2.5-pro:thinking";
+export const NANO_GPT_MIMO_THINKING_SUBMODEL = "xiaomi/mimo-v2.5-pro:thinking";
 export const NANO_GPT_GLM_SUBMODEL = "zai-org/glm-5.2";
 export const NANO_GPT_MIMO_THINKING_MODEL_TYPE =
 	`nanogpt|${NANO_GPT_MIMO_THINKING_SUBMODEL}` as const;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -18,8 +18,6 @@ export type ModelType =
 	| typeof NANO_GPT_MIMO_THINKING_MODEL_TYPE
 	| typeof NANO_GPT_GLM_MODEL_TYPE;
 
-export type LegacyModelType = ModelType | "nanogpt" | "glm";
-
 export type ScraperProvider = "jina" | "firecrawl";
 
 const anthropic = createAnthropic({
@@ -71,15 +69,3 @@ export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {
 	anthropic: 128000,
 	deepseek: 32000,
 };
-
-export function normalizeModelType(model: LegacyModelType): ModelType {
-	if (model === "nanogpt") {
-		return NANO_GPT_MIMO_THINKING_MODEL_TYPE;
-	}
-
-	if (model === "glm") {
-		return NANO_GPT_GLM_MODEL_TYPE;
-	}
-
-	return model;
-}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -8,7 +8,8 @@ export type ModelType =
 	| "google_flash"
 	| "anthropic"
 	| "deepseek"
-	| "nanogpt";
+	| "nanogpt"
+	| "glm";
 
 export type ScraperProvider = "jina" | "firecrawl";
 
@@ -41,6 +42,8 @@ export const mimoThinkingModel = openaiCompatible(
 	"xiaomi/mimo-v2.5-pro:thinking",
 );
 
+export const glmModel = openaiCompatible("zai-org/glm-5.2");
+
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
 export const deepseekModel = deepseek("deepseek-v4-pro");
@@ -50,6 +53,7 @@ export const MODEL_MAP = {
 	google: googleModel,
 	google_flash: googleFlashModel,
 	nanogpt: mimoThinkingModel,
+	glm: glmModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
 } as const;

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -365,6 +365,23 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									Mimo V2.5 Pro
 								</label>
 							</div>
+							<div className="flex items-center gap-2">
+								<input
+									type="radio"
+									id="glm_model"
+									name="model"
+									value="glm"
+									checked={model === "glm"}
+									onChange={(e) => setModel(e.target.value as ModelType)}
+									className="scale-125"
+								/>
+								<label
+									htmlFor="glm_model"
+									className="text-gray-700 dark:text-gray-300"
+								>
+									GLM 5.2
+								</label>
+							</div>
 						</div>
 					</div>
 

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -2,11 +2,9 @@ import { useCompletion } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
-	type LegacyModelType,
 	type ModelType,
 	NANO_GPT_GLM_MODEL_TYPE,
 	NANO_GPT_MIMO_THINKING_MODEL_TYPE,
-	normalizeModelType,
 	type ScraperProvider,
 } from "@/lib/models";
 
@@ -18,24 +16,17 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [fontSize, setFontSize] = useLocalStorage("fontSize", 3);
 	const [isDarkMode, setIsDarkMode] = useLocalStorage("darkMode", false);
 	const [mode, setMode] = useLocalStorage<Mode>("mode", "light_novel");
-	const [model, setModel] = useLocalStorage<LegacyModelType>("model", "google");
+	const [model, setModel] = useLocalStorage<ModelType>("model", "google");
 	const [scraperProvider, setScraperProvider] =
 		useLocalStorage<ScraperProvider>("scraperProvider", "jina");
 	const [ignoreCache, setIgnoreCache] = useState(false);
 	const [continuedCompletionPrefix, setContinuedCompletionPrefix] =
 		useState("");
-	const selectedModel = normalizeModelType(model);
 
 	useEffect(() => {
 		// Update dark mode class on html element
 		document.documentElement.classList.toggle("dark", isDarkMode);
 	}, [isDarkMode]);
-
-	useEffect(() => {
-		if (selectedModel !== model) {
-			setModel(selectedModel);
-		}
-	}, [model, selectedModel, setModel]);
 
 	const {
 		completion,
@@ -55,7 +46,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 		body: {
 			ignoreCache,
 			mode,
-			model: selectedModel,
+			model,
 			scraperProvider,
 		},
 	});
@@ -94,7 +85,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			body: {
 				ignoreCache,
 				mode,
-				model: selectedModel,
+				model,
 				scraperProvider,
 			},
 		});
@@ -116,7 +107,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			body: {
 				ignoreCache: true,
 				mode,
-				model: selectedModel,
+				model,
 				scraperProvider,
 				continueFrom: currentCompletion,
 			},
@@ -300,7 +291,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="google_model"
 									name="model"
 									value="google"
-									checked={selectedModel === "google"}
+									checked={model === "google"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -317,7 +308,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="google_flash_model"
 									name="model"
 									value="google_flash"
-									checked={selectedModel === "google_flash"}
+									checked={model === "google_flash"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -334,7 +325,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="deepseek_model"
 									name="model"
 									value="deepseek"
-									checked={selectedModel === "deepseek"}
+									checked={model === "deepseek"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -351,7 +342,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="anthropic_model"
 									name="model"
 									value="anthropic"
-									checked={selectedModel === "anthropic"}
+									checked={model === "anthropic"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -368,7 +359,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="nanogpt_model"
 									name="model"
 									value={NANO_GPT_MIMO_THINKING_MODEL_TYPE}
-									checked={selectedModel === NANO_GPT_MIMO_THINKING_MODEL_TYPE}
+									checked={model === NANO_GPT_MIMO_THINKING_MODEL_TYPE}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -385,7 +376,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="glm_model"
 									name="model"
 									value={NANO_GPT_GLM_MODEL_TYPE}
-									checked={selectedModel === NANO_GPT_GLM_MODEL_TYPE}
+									checked={model === NANO_GPT_GLM_MODEL_TYPE}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -2,11 +2,11 @@ import { useCompletion } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
+	type LegacyModelType,
+	type ModelType,
 	NANO_GPT_GLM_MODEL_TYPE,
 	NANO_GPT_MIMO_THINKING_MODEL_TYPE,
 	normalizeModelType,
-	type LegacyModelType,
-	type ModelType,
 	type ScraperProvider,
 } from "@/lib/models";
 

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -1,7 +1,14 @@
 import { useCompletion } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
-import type { ModelType, ScraperProvider } from "@/lib/models";
+import {
+	NANO_GPT_GLM_MODEL_TYPE,
+	NANO_GPT_MIMO_THINKING_MODEL_TYPE,
+	normalizeModelType,
+	type LegacyModelType,
+	type ModelType,
+	type ScraperProvider,
+} from "@/lib/models";
 
 import type { Mode } from "@/lib/translation/constants";
 import { getNextChapterUrl, getPreviousChapterUrl } from "@/lib/utils";
@@ -11,17 +18,24 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [fontSize, setFontSize] = useLocalStorage("fontSize", 3);
 	const [isDarkMode, setIsDarkMode] = useLocalStorage("darkMode", false);
 	const [mode, setMode] = useLocalStorage<Mode>("mode", "light_novel");
-	const [model, setModel] = useLocalStorage<ModelType>("model", "google");
+	const [model, setModel] = useLocalStorage<LegacyModelType>("model", "google");
 	const [scraperProvider, setScraperProvider] =
 		useLocalStorage<ScraperProvider>("scraperProvider", "jina");
 	const [ignoreCache, setIgnoreCache] = useState(false);
 	const [continuedCompletionPrefix, setContinuedCompletionPrefix] =
 		useState("");
+	const selectedModel = normalizeModelType(model);
 
 	useEffect(() => {
 		// Update dark mode class on html element
 		document.documentElement.classList.toggle("dark", isDarkMode);
 	}, [isDarkMode]);
+
+	useEffect(() => {
+		if (selectedModel !== model) {
+			setModel(selectedModel);
+		}
+	}, [model, selectedModel, setModel]);
 
 	const {
 		completion,
@@ -41,7 +55,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 		body: {
 			ignoreCache,
 			mode,
-			model,
+			model: selectedModel,
 			scraperProvider,
 		},
 	});
@@ -80,7 +94,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			body: {
 				ignoreCache,
 				mode,
-				model,
+				model: selectedModel,
 				scraperProvider,
 			},
 		});
@@ -102,7 +116,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			body: {
 				ignoreCache: true,
 				mode,
-				model,
+				model: selectedModel,
 				scraperProvider,
 				continueFrom: currentCompletion,
 			},
@@ -286,7 +300,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="google_model"
 									name="model"
 									value="google"
-									checked={model === "google"}
+									checked={selectedModel === "google"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -303,7 +317,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="google_flash_model"
 									name="model"
 									value="google_flash"
-									checked={model === "google_flash"}
+									checked={selectedModel === "google_flash"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -320,7 +334,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="deepseek_model"
 									name="model"
 									value="deepseek"
-									checked={model === "deepseek"}
+									checked={selectedModel === "deepseek"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -337,7 +351,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									id="anthropic_model"
 									name="model"
 									value="anthropic"
-									checked={model === "anthropic"}
+									checked={selectedModel === "anthropic"}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -353,8 +367,8 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									type="radio"
 									id="nanogpt_model"
 									name="model"
-									value="nanogpt"
-									checked={model === "nanogpt"}
+									value={NANO_GPT_MIMO_THINKING_MODEL_TYPE}
+									checked={selectedModel === NANO_GPT_MIMO_THINKING_MODEL_TYPE}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>
@@ -370,8 +384,8 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									type="radio"
 									id="glm_model"
 									name="model"
-									value="glm"
-									checked={model === "glm"}
+									value={NANO_GPT_GLM_MODEL_TYPE}
+									checked={selectedModel === NANO_GPT_GLM_MODEL_TYPE}
 									onChange={(e) => setModel(e.target.value as ModelType)}
 									className="scale-125"
 								/>

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -4,9 +4,11 @@ import type { APIRoute } from "astro";
 import delay from "delay";
 import { crawl } from "@/lib/crawler";
 import {
+	type LegacyModelType,
 	MODEL_MAP,
 	MODEL_MAX_TOKENS,
 	type ModelType,
+	normalizeModelType,
 	type ScraperProvider,
 } from "@/lib/models";
 import { getNextChapterUrl } from "@/lib/utils";
@@ -217,17 +219,18 @@ export const POST: APIRoute = async ({ request }) => {
 		prompt: string;
 		ignoreCache: boolean;
 		mode: Mode;
-		model: ModelType;
+		model: LegacyModelType;
 		scraperProvider: ScraperProvider;
 		continueFrom?: string;
 	} = await request.json();
 	const url = prompt;
+	const normalizedModel = normalizeModelType(model);
 
 	if (continueFrom?.trim()) {
 		const result = await getContinuationStreamResult(
 			url,
 			mode,
-			model,
+			normalizedModel,
 			scraperProvider,
 			continueFrom,
 		);
@@ -241,7 +244,7 @@ export const POST: APIRoute = async ({ request }) => {
 		url,
 		mode,
 		ignoreCache,
-		model,
+		normalizedModel,
 		scraperProvider,
 	);
 
@@ -251,7 +254,7 @@ export const POST: APIRoute = async ({ request }) => {
 			nextChapterUrl,
 			mode,
 			ignoreCache,
-			model,
+			normalizedModel,
 			scraperProvider,
 		);
 	}

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -4,11 +4,9 @@ import type { APIRoute } from "astro";
 import delay from "delay";
 import { crawl } from "@/lib/crawler";
 import {
-	type LegacyModelType,
 	MODEL_MAP,
 	MODEL_MAX_TOKENS,
 	type ModelType,
-	normalizeModelType,
 	type ScraperProvider,
 } from "@/lib/models";
 import { getNextChapterUrl } from "@/lib/utils";
@@ -219,18 +217,17 @@ export const POST: APIRoute = async ({ request }) => {
 		prompt: string;
 		ignoreCache: boolean;
 		mode: Mode;
-		model: LegacyModelType;
+		model: ModelType;
 		scraperProvider: ScraperProvider;
 		continueFrom?: string;
 	} = await request.json();
 	const url = prompt;
-	const normalizedModel = normalizeModelType(model);
 
 	if (continueFrom?.trim()) {
 		const result = await getContinuationStreamResult(
 			url,
 			mode,
-			normalizedModel,
+			model,
 			scraperProvider,
 			continueFrom,
 		);
@@ -244,7 +241,7 @@ export const POST: APIRoute = async ({ request }) => {
 		url,
 		mode,
 		ignoreCache,
-		normalizedModel,
+		model,
 		scraperProvider,
 	);
 
@@ -254,7 +251,7 @@ export const POST: APIRoute = async ({ request }) => {
 			nextChapterUrl,
 			mode,
 			ignoreCache,
-			normalizedModel,
+			model,
 			scraperProvider,
 		);
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add GLM 5.2 through Nano GPT's OpenAI-compatible provider
- Store Nano GPT-backed model choices as `nanogpt|<submodel>` values, including `nanogpt|zai-org/glm-5.2`
- Expose GLM 5.2 in the translation model selector
- Remove legacy `nanogpt`/`glm` model key compatibility
- Rename the Nano GPT OpenAI-compatible client for clearer call-site intent

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fce7afba-cbf0-4360-b7e6-c764fe3154b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fce7afba-cbf0-4360-b7e6-c764fe3154b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

