### PR TITLE
Preserve chapter number padding in pagination URLs

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -18,6 +18,10 @@ test("getNextChapterUrl should increment chapter number correctly", () => {
 			input: "https://www.bq01.cc/index/38697/86.html",
 			expected: "https://www.bq01.cc/index/38697/87.html",
 		},
+		{
+			input: "https://example.com/chapter-001.html",
+			expected: "https://example.com/chapter-002.html",
+		},
 	];
 	for (const { input, expected } of testUrls) {
 		expect(getNextChapterUrl(input)).toBe(expected);
@@ -39,6 +43,10 @@ test("getPreviousChapterUrl should decrement chapter number correctly", () => {
 		{
 			input: "https://www.bq01.cc/index/38697/86.html",
 			expected: "https://www.bq01.cc/index/38697/85.html",
+		},
+		{
+			input: "https://example.com/chapter-002.html",
+			expected: "https://example.com/chapter-001.html",
 		},
 	];
 	for (const { input, expected } of testUrls) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -42,7 +42,10 @@ export function getPreviousChapterUrl(inputURL: string) {
 	return newUrl;
 }
 
-function formatChapterNumber(chapterNumber: number, previousChapterNumber?: string) {
+function formatChapterNumber(
+	chapterNumber: number,
+	previousChapterNumber?: string,
+) {
 	const nextChapterNumber = chapterNumber.toString();
 
 	if (chapterNumber < 0 || !previousChapterNumber) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -11,10 +11,14 @@ export function getNextChapterUrl(inputURL: string) {
 
 	// Change chapter number by change value
 	const newChapterNumber = Number(chapterNumber) + 1;
+	const formattedChapterNumber = formatChapterNumber(
+		newChapterNumber,
+		chapterNumber,
+	);
 
 	const newUrl = inputURL.replace(
 		new RegExp(`${chapterNumber}(?=[^\\d]*$)`),
-		newChapterNumber.toString(),
+		formattedChapterNumber,
 	);
 	return newUrl;
 }
@@ -25,11 +29,25 @@ export function getPreviousChapterUrl(inputURL: string) {
 
 	// Change chapter number by change value
 	const newChapterNumber = Number(chapterNumber) - 1;
+	const formattedChapterNumber = formatChapterNumber(
+		newChapterNumber,
+		chapterNumber,
+	);
 
 	// Replace chapter number in url
 	const newUrl = inputURL.replace(
 		new RegExp(`${chapterNumber}(?=[^\\d]*$)`),
-		newChapterNumber.toString(),
+		formattedChapterNumber,
 	);
 	return newUrl;
+}
+
+function formatChapterNumber(chapterNumber: number, previousChapterNumber?: string) {
+	const nextChapterNumber = chapterNumber.toString();
+
+	if (chapterNumber < 0 || !previousChapterNumber) {
+		return nextChapterNumber;
+	}
+
+	return nextChapterNumber.padStart(previousChapterNumber.length, "0");
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Preserve leading zero padding when incrementing or decrementing chapter numbers in URLs
- Add regression coverage for zero-padded chapter URLs

## Tests
- `npm test -- --run src/lib/utils.test.ts`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d84afc-98c6-42ac-bcbb-0c9de3194358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d84afc-98c6-42ac-bcbb-0c9de3194358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

