### PR TITLE
Add Nano GPT Gemini Flash model

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -5,10 +5,13 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
 export const NANO_GPT_MIMO_THINKING_SUBMODEL = "xiaomi/mimo-v2.5-pro:thinking";
 export const NANO_GPT_GLM_SUBMODEL = "zai-org/glm-5.2";
+export const NANO_GPT_GEMINI_FLASH_SUBMODEL = "google/gemini-3.5-flash";
 export const NANO_GPT_MIMO_THINKING_MODEL_TYPE =
 	`nanogpt|${NANO_GPT_MIMO_THINKING_SUBMODEL}` as const;
 export const NANO_GPT_GLM_MODEL_TYPE =
 	`nanogpt|${NANO_GPT_GLM_SUBMODEL}` as const;
+export const NANO_GPT_GEMINI_FLASH_MODEL_TYPE =
+	`nanogpt|${NANO_GPT_GEMINI_FLASH_SUBMODEL}` as const;
 
 export type ModelType =
 	| "google"
@@ -16,7 +19,8 @@ export type ModelType =
 	| "anthropic"
 	| "deepseek"
 	| typeof NANO_GPT_MIMO_THINKING_MODEL_TYPE
-	| typeof NANO_GPT_GLM_MODEL_TYPE;
+	| typeof NANO_GPT_GLM_MODEL_TYPE
+	| typeof NANO_GPT_GEMINI_FLASH_MODEL_TYPE;
 
 export type ScraperProvider = "jina" | "firecrawl";
 
@@ -51,6 +55,10 @@ export const mimoThinkingModel = nanoGptOpenAICompatible(
 
 export const glmModel = nanoGptOpenAICompatible(NANO_GPT_GLM_SUBMODEL);
 
+export const nanoGptGeminiFlashModel = nanoGptOpenAICompatible(
+	NANO_GPT_GEMINI_FLASH_SUBMODEL,
+);
+
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
 export const deepseekModel = deepseek("deepseek-v4-pro");
@@ -63,6 +71,7 @@ export const MODEL_MAP = {
 	[NANO_GPT_GLM_MODEL_TYPE]: glmModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
+	[NANO_GPT_GEMINI_FLASH_MODEL_TYPE]: nanoGptGeminiFlashModel,
 } as const;
 
 export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	type ModelType,
+	NANO_GPT_GEMINI_FLASH_MODEL_TYPE,
 	NANO_GPT_GLM_MODEL_TYPE,
 	NANO_GPT_MIMO_THINKING_MODEL_TYPE,
 	type ScraperProvider,
@@ -385,6 +386,23 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									className="text-gray-700 dark:text-gray-300"
 								>
 									GLM 5.2
+								</label>
+							</div>
+							<div className="flex items-center gap-2">
+								<input
+									type="radio"
+									id="nanogpt_gemini_flash_model"
+									name="model"
+									value={NANO_GPT_GEMINI_FLASH_MODEL_TYPE}
+									checked={model === NANO_GPT_GEMINI_FLASH_MODEL_TYPE}
+									onChange={(e) => setModel(e.target.value as ModelType)}
+									className="scale-125"
+								/>
+								<label
+									htmlFor="nanogpt_gemini_flash_model"
+									className="text-gray-700 dark:text-gray-300"
+								>
+									Nano GPT Gemini 3.5 Flash
 								</label>
 							</div>
 						</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Nano GPT-backed `google/gemini-3.5-flash` model type and provider instance.
- Add the new Nano GPT Gemini Flash radio option at the end of the AI model selector.

## Verification
- `npm run lint`
- `npm run build`
- `npm test -- --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18ed8110-dfc2-460d-9176-a29c286a4b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18ed8110-dfc2-460d-9176-a29c286a4b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

