### PR TITLE
Refactor Nano GPT model registry

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,24 +3,51 @@ import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
-export const NANO_GPT_MIMO_THINKING_SUBMODEL = "xiaomi/mimo-v2.5-pro:thinking";
-export const NANO_GPT_GLM_SUBMODEL = "zai-org/glm-5.2";
-export const NANO_GPT_GEMINI_FLASH_SUBMODEL = "google/gemini-3.5-flash";
-export const NANO_GPT_MIMO_THINKING_MODEL_TYPE =
-	`nanogpt|${NANO_GPT_MIMO_THINKING_SUBMODEL}` as const;
-export const NANO_GPT_GLM_MODEL_TYPE =
-	`nanogpt|${NANO_GPT_GLM_SUBMODEL}` as const;
-export const NANO_GPT_GEMINI_FLASH_MODEL_TYPE =
-	`nanogpt|${NANO_GPT_GEMINI_FLASH_SUBMODEL}` as const;
+function nanoGptModel<const TSubmodel extends string>({
+	submodel,
+	label,
+	inputId,
+}: {
+	submodel: TSubmodel;
+	label: string;
+	inputId: string;
+}) {
+	return {
+		submodel,
+		modelType: `nanogpt|${submodel}` as `nanogpt|${TSubmodel}`,
+		label,
+		inputId,
+	};
+}
+
+export const NANO_GPT_MODELS = {
+	mimoThinking: nanoGptModel({
+		submodel: "xiaomi/mimo-v2.5-pro:thinking",
+		label: "Mimo V2.5 Pro",
+		inputId: "nanogpt_model",
+	}),
+	glm: nanoGptModel({
+		submodel: "zai-org/glm-5.2",
+		label: "GLM 5.2",
+		inputId: "glm_model",
+	}),
+	geminiFlash: nanoGptModel({
+		submodel: "google/gemini-3.5-flash",
+		label: "Nano GPT Gemini 3.5 Flash",
+		inputId: "nanogpt_gemini_flash_model",
+	}),
+} as const;
+
+export type NanoGptModel =
+	(typeof NANO_GPT_MODELS)[keyof typeof NANO_GPT_MODELS];
+export type NanoGptModelType = NanoGptModel["modelType"];
 
 export type ModelType =
 	| "google"
 	| "google_flash"
 	| "anthropic"
 	| "deepseek"
-	| typeof NANO_GPT_MIMO_THINKING_MODEL_TYPE
-	| typeof NANO_GPT_GLM_MODEL_TYPE
-	| typeof NANO_GPT_GEMINI_FLASH_MODEL_TYPE;
+	| NanoGptModelType;
 
 export type ScraperProvider = "jina" | "firecrawl";
 
@@ -49,15 +76,12 @@ export const googleModel = google("gemini-3.1-pro-preview");
 
 export const googleFlashModel = google("gemini-3.5-flash");
 
-export const mimoThinkingModel = nanoGptOpenAICompatible(
-	NANO_GPT_MIMO_THINKING_SUBMODEL,
-);
-
-export const glmModel = nanoGptOpenAICompatible(NANO_GPT_GLM_SUBMODEL);
-
-export const nanoGptGeminiFlashModel = nanoGptOpenAICompatible(
-	NANO_GPT_GEMINI_FLASH_SUBMODEL,
-);
+const nanoGptModelMap = Object.fromEntries(
+	Object.values(NANO_GPT_MODELS).map(({ modelType, submodel }) => [
+		modelType,
+		nanoGptOpenAICompatible(submodel),
+	]),
+) as Record<NanoGptModelType, ReturnType<typeof nanoGptOpenAICompatible>>;
 
 // Keep the persisted "deepseek" option stable while targeting DeepSeek's
 // current recommended production model.
@@ -67,11 +91,9 @@ export const deepseekModel = deepseek("deepseek-v4-pro");
 export const MODEL_MAP = {
 	google: googleModel,
 	google_flash: googleFlashModel,
-	[NANO_GPT_MIMO_THINKING_MODEL_TYPE]: mimoThinkingModel,
-	[NANO_GPT_GLM_MODEL_TYPE]: glmModel,
 	anthropic: anthropicModel,
 	deepseek: deepseekModel,
-	[NANO_GPT_GEMINI_FLASH_MODEL_TYPE]: nanoGptGeminiFlashModel,
+	...nanoGptModelMap,
 } as const;
 
 export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -6,17 +6,14 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 function nanoGptModel<const TSubmodel extends string>({
 	submodel,
 	label,
-	inputId,
 }: {
 	submodel: TSubmodel;
 	label: string;
-	inputId: string;
 }) {
 	return {
 		submodel,
 		modelType: `nanogpt|${submodel}` as `nanogpt|${TSubmodel}`,
 		label,
-		inputId,
 	};
 }
 
@@ -24,17 +21,14 @@ export const NANO_GPT_MODELS = {
 	mimoThinking: nanoGptModel({
 		submodel: "xiaomi/mimo-v2.5-pro:thinking",
 		label: "Mimo V2.5 Pro",
-		inputId: "nanogpt_model",
 	}),
 	glm: nanoGptModel({
 		submodel: "zai-org/glm-5.2",
 		label: "GLM 5.2",
-		inputId: "glm_model",
 	}),
 	geminiFlash: nanoGptModel({
 		submodel: "google/gemini-3.5-flash",
 		label: "Nano GPT Gemini 3.5 Flash",
-		inputId: "nanogpt_gemini_flash_model",
 	}),
 } as const;
 

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -354,11 +354,11 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									Claude
 								</label>
 							</div>
-							{NANO_GPT_MODEL_OPTIONS.map(({ inputId, modelType, label }) => (
+							{NANO_GPT_MODEL_OPTIONS.map(({ modelType, label }) => (
 								<div key={modelType} className="flex items-center gap-2">
 									<input
 										type="radio"
-										id={inputId}
+										id={modelType}
 										name="model"
 										value={modelType}
 										checked={model === modelType}
@@ -366,7 +366,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 										className="scale-125"
 									/>
 									<label
-										htmlFor={inputId}
+										htmlFor={modelType}
 										className="text-gray-700 dark:text-gray-300"
 									>
 										{label}

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -3,15 +3,15 @@ import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	type ModelType,
-	NANO_GPT_GEMINI_FLASH_MODEL_TYPE,
-	NANO_GPT_GLM_MODEL_TYPE,
-	NANO_GPT_MIMO_THINKING_MODEL_TYPE,
+	NANO_GPT_MODELS,
 	type ScraperProvider,
 } from "@/lib/models";
 
 import type { Mode } from "@/lib/translation/constants";
 import { getNextChapterUrl, getPreviousChapterUrl } from "@/lib/utils";
 import { addLink, setTranslateUrl } from "../pocket";
+
+const NANO_GPT_MODEL_OPTIONS = Object.values(NANO_GPT_MODELS);
 
 const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [fontSize, setFontSize] = useLocalStorage("fontSize", 3);
@@ -354,57 +354,25 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 									Claude
 								</label>
 							</div>
-							<div className="flex items-center gap-2">
-								<input
-									type="radio"
-									id="nanogpt_model"
-									name="model"
-									value={NANO_GPT_MIMO_THINKING_MODEL_TYPE}
-									checked={model === NANO_GPT_MIMO_THINKING_MODEL_TYPE}
-									onChange={(e) => setModel(e.target.value as ModelType)}
-									className="scale-125"
-								/>
-								<label
-									htmlFor="nanogpt_model"
-									className="text-gray-700 dark:text-gray-300"
-								>
-									Mimo V2.5 Pro
-								</label>
-							</div>
-							<div className="flex items-center gap-2">
-								<input
-									type="radio"
-									id="glm_model"
-									name="model"
-									value={NANO_GPT_GLM_MODEL_TYPE}
-									checked={model === NANO_GPT_GLM_MODEL_TYPE}
-									onChange={(e) => setModel(e.target.value as ModelType)}
-									className="scale-125"
-								/>
-								<label
-									htmlFor="glm_model"
-									className="text-gray-700 dark:text-gray-300"
-								>
-									GLM 5.2
-								</label>
-							</div>
-							<div className="flex items-center gap-2">
-								<input
-									type="radio"
-									id="nanogpt_gemini_flash_model"
-									name="model"
-									value={NANO_GPT_GEMINI_FLASH_MODEL_TYPE}
-									checked={model === NANO_GPT_GEMINI_FLASH_MODEL_TYPE}
-									onChange={(e) => setModel(e.target.value as ModelType)}
-									className="scale-125"
-								/>
-								<label
-									htmlFor="nanogpt_gemini_flash_model"
-									className="text-gray-700 dark:text-gray-300"
-								>
-									Nano GPT Gemini 3.5 Flash
-								</label>
-							</div>
+							{NANO_GPT_MODEL_OPTIONS.map(({ inputId, modelType, label }) => (
+								<div key={modelType} className="flex items-center gap-2">
+									<input
+										type="radio"
+										id={inputId}
+										name="model"
+										value={modelType}
+										checked={model === modelType}
+										onChange={(e) => setModel(e.target.value as ModelType)}
+										className="scale-125"
+									/>
+									<label
+										htmlFor={inputId}
+										className="text-gray-700 dark:text-gray-300"
+									>
+										{label}
+									</label>
+								</div>
+							))}
 						</div>
 					</div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactor Nano GPT model metadata into a single typed `NANO_GPT_MODELS` registry.
- Derive the Nano GPT model type union from that registry instead of separate per-model constants.
- Render Nano GPT radio options from the shared registry, using each `modelType` as the input id and keeping Nano GPT Gemini Flash last.

## Verification
- `npm run lint`
- `npm run build`
- `npm test -- --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18ed8110-dfc2-460d-9176-a29c286a4b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18ed8110-dfc2-460d-9176-a29c286a4b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

