### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Astro v6 (SSR) + React 19 app — an AI web-novel translator ("AI Convert Translator"). There is only one service to run. Node `>=22.0.0` is required (see `package.json` `engines`).
+
+Standard commands live in `package.json` scripts; use them directly:
+- Dev server: `npm run dev` (Astro dev on `http://localhost:4321`; override port with `PORT`).
+- Lint: `npm run lint` (Biome). Build: `npm run build` (`astro check && astro build`). Tests: `npm run test` (Vitest, runs once and exits in non-interactive shells).
+
+Non-obvious caveats:
+- **External dependencies, no local services.** There is no database, docker-compose, or local backend in this repo. The app talks to remote HTTP APIs at runtime.
+- **PocketBase is remote and hardcoded** at `https://pocketbase.codedao.cc` in `src/pocket.ts` (no env override). The homepage (`src/pages/index.astro`) calls `getTranslateUrl()` during SSR, so if that host is unreachable the page render fails. It is reachable from the cloud VM.
+- **Translation requires an LLM API key.** `POST /api/translate` scrapes the source chapter (default scraper is Jina at `https://r.jina.ai`, which works without a key) and then calls an LLM. The default model is Google Gemini, which needs `GOOGLE_GENERATIVE_AI_KEY`. Without an LLM key the whole pipeline runs (scraping succeeds) but the LLM step throws `AI_LoadAPIKeyError`. Set keys in a `.env` file at the repo root (env is read via `import.meta.env.*`).
+- Relevant env vars: `GOOGLE_GENERATIVE_AI_KEY` (default model), `CLAUDE_AI_KEY`, `DEEPSEEK_API_KEY`, `NANO_GPT_API_KEY` (alternative models); `JINA_API_KEY` (optional, raises scraper limits), `FIRECRAWL_API_KEY` (only if scraper switched to Firecrawl); `PORT` (optional).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the **AI Convert Translator** Astro v6 (SSR) + React 19 app and documents non-obvious caveats for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the single-service layout, required Node version, standard commands, and the key non-obvious caveats (remote hardcoded PocketBase, LLM key requirement for translation).
- Update script for the environment: `npm install`.

## Verification

Ran against the repo on Node v22.14.0:

- `npm install` — installs dependencies
- `npm run lint` (Biome) — passed, 25 files checked
- `npm run test` (Vitest) — 2 tests passed
- `npm run build` (`astro check && astro build`) — 0 errors, server build complete
- `npm run dev` — dev server up on `http://localhost:4321`; homepage (SSR + remote PocketBase) and `/history` both return 200 and render correctly

The translate pipeline runs end-to-end (Jina scraping succeeds); only the final LLM call requires an API key (`GOOGLE_GENERATIVE_AI_KEY` for the default Gemini model), which is not set in this environment.

<a href="https://cursor.com/agents/bc-c65cf1e9-cf13-454e-9f4d-5ffa5774b7d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_translator_ui_demo.mp4"><img src="https://cursor.com/artifacts/c/art-5d8eb76f-12f1-41a3-a6e5-af007b3ac168" alt="ai_translator_ui_demo.mp4" /></a>

![Home page loaded](https://cursor.com/artifacts/c/art-09471c9b-e0e4-4079-99b4-3b4240ca5fa4)
![History page](https://cursor.com/artifacts/c/art-ce0b61a3-d6d9-42df-9435-0465b5f654ab)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c65cf1e9-cf13-454e-9f4d-5ffa5774b7d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65cf1e9-cf13-454e-9f4d-5ffa5774b7d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

