### PR TITLE
Disable low-quality Nano GPT models

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -18,10 +18,11 @@ function nanoGptModel<const TSubmodel extends string>({
 }
 
 export const NANO_GPT_MODELS = {
-	mimoThinking: nanoGptModel({
-		submodel: "xiaomi/mimo-v2.5-pro:thinking",
-		label: "Mimo V2.5 Pro",
-	}),
+	// Disabled: output quality was too low for translation use.
+	// mimoThinking: nanoGptModel({
+	// 	submodel: "xiaomi/mimo-v2.5-pro:thinking",
+	// 	label: "Mimo V2.5 Pro",
+	// }),
 	glm: nanoGptModel({
 		submodel: "zai-org/glm-5.2",
 		label: "GLM 5.2",
@@ -30,10 +31,11 @@ export const NANO_GPT_MODELS = {
 		submodel: "google/gemini-3.5-flash",
 		label: "Gemini 3.5 Flash",
 	}),
-	grok: nanoGptModel({
-		submodel: "x-ai/grok-4.5",
-		label: "Grok 4.5",
-	}),
+	// Disabled: output quality was too low for translation use.
+	// grok: nanoGptModel({
+	// 	submodel: "x-ai/grok-4.5",
+	// 	label: "Grok 4.5",
+	// }),
 } as const;
 
 export type NanoGptModel =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Comment out Mimo V2.5 Pro and Grok 4.5 Nano GPT model entries.
- Add inline comments noting they were disabled due to low output quality.

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-665e9dad-f9fb-4675-ba5b-b2cf9a30488e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-665e9dad-f9fb-4675-ba5b-b2cf9a30488e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

