### PR TITLE
Add Muse Spark Nano GPT model

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -31,6 +31,10 @@ export const NANO_GPT_MODELS = {
 		submodel: "google/gemini-3.5-flash",
 		label: "Gemini 3.5 Flash",
 	}),
+	museSpark: nanoGptModel({
+		submodel: "meta/muse-spark-1.1",
+		label: "Muse Spark 1.1",
+	}),
 	// Disabled: output quality was too low for translation use.
 	// grok: nanoGptModel({
 	// 	submodel: "x-ai/grok-4.5",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Muse Spark 1.1 as a Nano GPT-backed model option using `meta/muse-spark-1.1`.
- Let the existing Nano GPT model map and UI option generation expose it automatically.

## Testing
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-665e9dad-f9fb-4675-ba5b-b2cf9a30488e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-665e9dad-f9fb-4675-ba5b-b2cf9a30488e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

