### PR TITLE
Persist last used translation model

### DIFF
--- a/src/lib/model-storage.test.ts
+++ b/src/lib/model-storage.test.ts
@@ -45,7 +45,9 @@ test("falls back to the legacy model key", () => {
 		model: JSON.stringify(NANO_GPT_MODELS.glm.modelType),
 	});
 
-	expect(getInitialModelFromStorage(storage)).toBe(NANO_GPT_MODELS.glm.modelType);
+	expect(getInitialModelFromStorage(storage)).toBe(
+		NANO_GPT_MODELS.glm.modelType,
+	);
 });
 
 test("returns the default model when storage is empty or invalid", () => {

--- a/src/lib/model-storage.test.ts
+++ b/src/lib/model-storage.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "vitest";
+
+import {
+	getInitialModelFromStorage,
+	LAST_USED_MODEL_STORAGE_KEY,
+	persistLastUsedModel,
+} from "./model-storage";
+import { DEFAULT_MODEL_TYPE, NANO_GPT_MODELS } from "./models";
+
+function createStorage(initialValues: Record<string, string> = {}): Storage {
+	const values = new Map(Object.entries(initialValues));
+
+	return {
+		get length() {
+			return values.size;
+		},
+		clear() {
+			values.clear();
+		},
+		getItem(key) {
+			return values.get(key) ?? null;
+		},
+		key(index) {
+			return Array.from(values.keys())[index] ?? null;
+		},
+		removeItem(key) {
+			values.delete(key);
+		},
+		setItem(key, value) {
+			values.set(key, value);
+		},
+	};
+}
+
+test("restores the last used model from storage", () => {
+	const storage = createStorage({
+		[LAST_USED_MODEL_STORAGE_KEY]: JSON.stringify("deepseek"),
+	});
+
+	expect(getInitialModelFromStorage(storage)).toBe("deepseek");
+});
+
+test("falls back to the legacy model key", () => {
+	const storage = createStorage({
+		model: JSON.stringify(NANO_GPT_MODELS.glm.modelType),
+	});
+
+	expect(getInitialModelFromStorage(storage)).toBe(NANO_GPT_MODELS.glm.modelType);
+});
+
+test("returns the default model when storage is empty or invalid", () => {
+	const storage = createStorage({
+		[LAST_USED_MODEL_STORAGE_KEY]: JSON.stringify("missing-model"),
+		model: JSON.stringify("also-missing"),
+	});
+
+	expect(getInitialModelFromStorage(storage)).toBe(DEFAULT_MODEL_TYPE);
+	expect(getInitialModelFromStorage()).toBe(DEFAULT_MODEL_TYPE);
+});
+
+test("persists the last used model as JSON", () => {
+	const storage = createStorage();
+
+	persistLastUsedModel("anthropic", storage);
+
+	expect(storage.getItem(LAST_USED_MODEL_STORAGE_KEY)).toBe(
+		JSON.stringify("anthropic"),
+	);
+});

--- a/src/lib/model-storage.ts
+++ b/src/lib/model-storage.ts
@@ -1,0 +1,56 @@
+import {
+	DEFAULT_MODEL_TYPE,
+	isModelType,
+	type ModelType,
+} from "@/lib/models";
+
+export const LAST_USED_MODEL_STORAGE_KEY = "lastUsedModel";
+
+const LEGACY_MODEL_STORAGE_KEY = "model";
+
+function getBrowserLocalStorage(): Storage | undefined {
+	return typeof window === "undefined" ? undefined : window.localStorage;
+}
+
+function parseStoredValue(value: string | null): unknown {
+	if (value === null) {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
+export function getInitialModelFromStorage(
+	storage = getBrowserLocalStorage(),
+): ModelType {
+	if (!storage) {
+		return DEFAULT_MODEL_TYPE;
+	}
+
+	const lastUsedModel = parseStoredValue(
+		storage.getItem(LAST_USED_MODEL_STORAGE_KEY),
+	);
+
+	if (isModelType(lastUsedModel)) {
+		return lastUsedModel;
+	}
+
+	const legacyModel = parseStoredValue(storage.getItem(LEGACY_MODEL_STORAGE_KEY));
+
+	if (isModelType(legacyModel)) {
+		return legacyModel;
+	}
+
+	return DEFAULT_MODEL_TYPE;
+}
+
+export function persistLastUsedModel(
+	model: ModelType,
+	storage = getBrowserLocalStorage(),
+): void {
+	storage?.setItem(LAST_USED_MODEL_STORAGE_KEY, JSON.stringify(model));
+}

--- a/src/lib/model-storage.ts
+++ b/src/lib/model-storage.ts
@@ -1,8 +1,4 @@
-import {
-	DEFAULT_MODEL_TYPE,
-	isModelType,
-	type ModelType,
-} from "@/lib/models";
+import { DEFAULT_MODEL_TYPE, isModelType, type ModelType } from "./models";
 
 export const LAST_USED_MODEL_STORAGE_KEY = "lastUsedModel";
 
@@ -39,7 +35,9 @@ export function getInitialModelFromStorage(
 		return lastUsedModel;
 	}
 
-	const legacyModel = parseStoredValue(storage.getItem(LEGACY_MODEL_STORAGE_KEY));
+	const legacyModel = parseStoredValue(
+		storage.getItem(LEGACY_MODEL_STORAGE_KEY),
+	);
 
 	if (isModelType(legacyModel)) {
 		return legacyModel;

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -53,6 +53,23 @@ export type ModelType =
 	| "deepseek"
 	| NanoGptModelType;
 
+export const DEFAULT_MODEL_TYPE = "google" satisfies ModelType;
+
+export const MODEL_TYPES = [
+	"google",
+	"google_flash",
+	"anthropic",
+	"deepseek",
+	...Object.values(NANO_GPT_MODELS).map(({ modelType }) => modelType),
+] as const satisfies readonly ModelType[];
+
+export function isModelType(value: unknown): value is ModelType {
+	return (
+		typeof value === "string" &&
+		(MODEL_TYPES as readonly string[]).includes(value)
+	);
+}
+
 export type ScraperProvider = "jina" | "firecrawl";
 
 const anthropic = createAnthropic({

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -6,6 +6,10 @@ import {
 	NANO_GPT_MODELS,
 	type ScraperProvider,
 } from "@/lib/models";
+import {
+	getInitialModelFromStorage,
+	persistLastUsedModel,
+} from "@/lib/model-storage";
 
 import type { Mode } from "@/lib/translation/constants";
 import { getNextChapterUrl, getPreviousChapterUrl } from "@/lib/utils";
@@ -17,7 +21,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [fontSize, setFontSize] = useLocalStorage("fontSize", 3);
 	const [isDarkMode, setIsDarkMode] = useLocalStorage("darkMode", false);
 	const [mode, setMode] = useLocalStorage<Mode>("mode", "light_novel");
-	const [model, setModel] = useLocalStorage<ModelType>("model", "google");
+	const [model, setModel] = useState<ModelType>(getInitialModelFromStorage);
 	const [scraperProvider, setScraperProvider] =
 		useLocalStorage<ScraperProvider>("scraperProvider", "jina");
 	const [ignoreCache, setIgnoreCache] = useState(false);
@@ -28,6 +32,10 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 		// Update dark mode class on html element
 		document.documentElement.classList.toggle("dark", isDarkMode);
 	}, [isDarkMode]);
+
+	useEffect(() => {
+		persistLastUsedModel(model);
+	}, [model]);
 
 	const {
 		completion,

--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -2,14 +2,14 @@ import { useCompletion } from "@ai-sdk/react";
 import { useEffect, useState } from "react";
 import { useLocalStorage } from "usehooks-ts";
 import {
+	getInitialModelFromStorage,
+	persistLastUsedModel,
+} from "@/lib/model-storage";
+import {
 	type ModelType,
 	NANO_GPT_MODELS,
 	type ScraperProvider,
 } from "@/lib/models";
-import {
-	getInitialModelFromStorage,
-	persistLastUsedModel,
-} from "@/lib/model-storage";
 
 import type { Mode } from "@/lib/translation/constants";
 import { getNextChapterUrl, getPreviousChapterUrl } from "@/lib/utils";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Persist the selected translation model to a dedicated `lastUsedModel` localStorage key
- Restore valid saved models on refresh, with fallback from the existing `model` key
- Add validation and tests for model storage behavior

## Testing
- `npm run build` passed before follow-up validation fixes
- Final lint/test/build rerun in progress
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2830ed5c-9532-4e49-adbb-56ee5df9938e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2830ed5c-9532-4e49-adbb-56ee5df9938e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

