### PR TITLE
Add Direct Translate mode for pasted text

### DIFF
--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -21,6 +21,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	const [scraperProvider, setScraperProvider] =
 		useLocalStorage<ScraperProvider>("scraperProvider", "jina");
 	const [ignoreCache, setIgnoreCache] = useState(false);
+	const [directTranslate, setDirectTranslate] = useState(false);
 	const [continuedCompletionPrefix, setContinuedCompletionPrefix] =
 		useState("");
 
@@ -49,6 +50,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			mode,
 			model,
 			scraperProvider,
+			directTranslate,
 		},
 	});
 
@@ -69,6 +71,10 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 	// }, [input]);
 
 	async function goToChapter(direction: "next" | "previous") {
+		if (directTranslate) {
+			return;
+		}
+
 		stop();
 		setContinuedCompletionPrefix("");
 
@@ -88,6 +94,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 				mode,
 				model,
 				scraperProvider,
+				directTranslate: false,
 			},
 		});
 
@@ -111,6 +118,7 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 				model,
 				scraperProvider,
 				continueFrom: currentCompletion,
+				directTranslate,
 			},
 		});
 	}
@@ -151,7 +159,11 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 							rows={3}
 							value={input}
 							onChange={handleInputChange}
-							placeholder="Enter URL For Translation"
+							placeholder={
+								directTranslate
+									? "Paste Text For Direct Translation"
+									: "Enter URL For Translation"
+							}
 							className="flex-1 rounded-lg border p-2 focus:outline-none focus:border-blue-500 bg-white dark:bg-gray-700 dark:text-white border-gray-300 dark:border-gray-600"
 						/>
 						{isLoading ? (
@@ -179,20 +191,37 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 				<div className="flex flex-col gap-4 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
 					{/* First row: Ignore Cache and Font/Theme controls */}
 					<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-						<div className="flex items-center gap-2">
-							<input
-								type="checkbox"
-								id="ignoreCache"
-								checked={ignoreCache}
-								onChange={(e) => setIgnoreCache(e.target.checked)}
-								className="rounded border-gray-300 dark:border-gray-600 scale-125"
-							/>
-							<label
-								htmlFor="ignoreCache"
-								className="text-gray-700 dark:text-gray-300 text-lg"
-							>
-								Ignore Cache
-							</label>
+						<div className="flex flex-wrap items-center gap-4">
+							<div className="flex items-center gap-2">
+								<input
+									type="checkbox"
+									id="ignoreCache"
+									checked={ignoreCache}
+									onChange={(e) => setIgnoreCache(e.target.checked)}
+									className="rounded border-gray-300 dark:border-gray-600 scale-125"
+								/>
+								<label
+									htmlFor="ignoreCache"
+									className="text-gray-700 dark:text-gray-300 text-lg"
+								>
+									Ignore Cache
+								</label>
+							</div>
+							<div className="flex items-center gap-2">
+								<input
+									type="checkbox"
+									id="directTranslate"
+									checked={directTranslate}
+									onChange={(e) => setDirectTranslate(e.target.checked)}
+									className="rounded border-gray-300 dark:border-gray-600 scale-125"
+								/>
+								<label
+									htmlFor="directTranslate"
+									className="text-gray-700 dark:text-gray-300 text-lg"
+								>
+									Direct Translate
+								</label>
+							</div>
 						</div>
 
 						<div className="flex gap-2">
@@ -476,14 +505,20 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 					)}
 				</div>
 
-				<div className="flex justify-between p-4 border-t dark:border-gray-700">
-					<button
-						type="button"
-						className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
-						onClick={() => goToChapter("previous")}
-					>
-						Previous Chapter
-					</button>
+				<div
+					className={`flex p-4 border-t dark:border-gray-700 ${
+						directTranslate ? "justify-center" : "justify-between"
+					}`}
+				>
+					{!directTranslate && (
+						<button
+							type="button"
+							className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
+							onClick={() => goToChapter("previous")}
+						>
+							Previous Chapter
+						</button>
+					)}
 					{canContinueTranslation && (
 						<button
 							type="button"
@@ -493,13 +528,15 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 							Continue
 						</button>
 					)}
-					<button
-						type="button"
-						className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
-						onClick={() => goToChapter("next")}
-					>
-						Next Chapter
-					</button>
+					{!directTranslate && (
+						<button
+							type="button"
+							className="bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition"
+							onClick={() => goToChapter("next")}
+						>
+							Next Chapter
+						</button>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -28,14 +28,11 @@ function getCacheKey(
 	return `${url}|${mode}|${model}|${scraperProvider}`;
 }
 
-async function getStreamResult(
-	url: string,
+async function getStreamResultFromSource(
+	source: string,
 	mode: Mode,
 	model: ModelType = "google",
-	scraperProvider: ScraperProvider = "jina",
 ): Promise<Result> {
-	const html = await crawl(url, scraperProvider);
-
 	const PROMPT_MAP = await getPromptMap();
 
 	console.time("streamText");
@@ -51,7 +48,7 @@ async function getStreamResult(
 				role: "user",
 				content: `Here are the original work you will be working with:
 <original>
-${html}
+${source}
 </original>`,
 			},
 		],
@@ -83,14 +80,25 @@ ${html}
 	return result;
 }
 
+async function getStreamResult(
+	url: string,
+	mode: Mode,
+	model: ModelType = "google",
+	scraperProvider: ScraperProvider = "jina",
+): Promise<Result> {
+	const html = await crawl(url, scraperProvider);
+	return getStreamResultFromSource(html, mode, model);
+}
+
 async function getContinuationStreamResult(
 	url: string,
 	mode: Mode,
 	model: ModelType = "google",
 	scraperProvider: ScraperProvider = "jina",
 	continueFrom: string,
+	directTranslate = false,
 ): Promise<Result> {
-	const html = await crawl(url, scraperProvider);
+	const html = directTranslate ? url : await crawl(url, scraperProvider);
 
 	const PROMPT_MAP = await getPromptMap();
 
@@ -213,6 +221,7 @@ export const POST: APIRoute = async ({ request }) => {
 		model = "google",
 		scraperProvider = "jina",
 		continueFrom,
+		directTranslate = false,
 	}: {
 		prompt: string;
 		ignoreCache: boolean;
@@ -220,6 +229,7 @@ export const POST: APIRoute = async ({ request }) => {
 		model: ModelType;
 		scraperProvider: ScraperProvider;
 		continueFrom?: string;
+		directTranslate?: boolean;
 	} = await request.json();
 	const url = prompt;
 
@@ -230,7 +240,18 @@ export const POST: APIRoute = async ({ request }) => {
 			model,
 			scraperProvider,
 			continueFrom,
+			directTranslate,
 		);
+
+		return (
+			result?.toTextStreamResponse() ?? new Response(null, { status: 501 })
+		);
+	}
+
+	// Direct translate: treat the prompt as the source text itself.
+	// No scraping, no cache, no next-chapter prefetch.
+	if (directTranslate) {
+		const result = await getStreamResultFromSource(prompt, mode, model);
 
 		return (
 			result?.toTextStreamResponse() ?? new Response(null, { status: 501 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Direct Translate** checkbox next to the existing **Ignore Cache** checkbox. When enabled, whatever is pasted into the textarea is sent to the LLM as the source text directly:

- No scraping (`crawl` is never called)
- No result cache (bypasses `RESULT_CACHE` entirely)
- No next-chapter URL prefetch

## Changes

### `src/pages/_Translate.tsx`
- New `directTranslate` state and a "Direct Translate" checkbox rendered next to "Ignore Cache".
- The flag is included in the request body for submit and Continue.
- Textarea placeholder switches to "Paste Text For Direct Translation" when the mode is on.
- Previous/Next Chapter buttons are hidden (and `goToChapter` guarded) in direct mode, since the input is raw text rather than a chapter URL. Continue still works.

### `src/pages/api/translate.ts`
- Extracted `getStreamResultFromSource(source, mode, model)` from `getStreamResult`, so the LLM call can be fed raw text; `getStreamResult` now crawls and delegates to it.
- `POST` accepts an optional `directTranslate` flag. When set, the handler streams a translation of the pasted `prompt` directly and returns early — skipping `getStreamFromCache` and the next-chapter prefetch.
- Continuation requests also honor the flag (uses the pasted text instead of re-scraping).

## Verification

- `npm run lint`, `npm run build` (astro check + build), and `npm run test` all pass.
- Smoke-tested against the dev server: a `directTranslate: true` request reaches `streamText` with no crawl and no cache-key logging, while a normal URL request still logs the cache key and goes through the cached path. (Both stop at `AI_LoadAPIKeyError` since no LLM key is configured in this environment.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f97cab03-b1e3-4bd9-9716-1a5fd8242bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f97cab03-b1e3-4bd9-9716-1a5fd8242bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

