### PR TITLE
Hide Scraper selector when Direct Translate is enabled (targets master)

### DIFF
--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -422,52 +422,54 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 						</div>
 					</div>
 
-					{/* Fourth row: Scraper Provider */}
-					<div className="flex flex-col lg:flex-row lg:items-center gap-3">
-						<span className="text-gray-700 dark:text-gray-300 font-medium text-sm whitespace-nowrap">
-							Scraper:
-						</span>
-						<div className="flex flex-wrap items-center gap-4">
-							<div className="flex items-center gap-2">
-								<input
-									type="radio"
-									id="scraper_jina"
-									name="scraperProvider"
-									value="jina"
-									checked={scraperProvider === "jina"}
-									onChange={(e) =>
-										setScraperProvider(e.target.value as ScraperProvider)
-									}
-									className="scale-125"
-								/>
-								<label
-									htmlFor="scraper_jina"
-									className="text-gray-700 dark:text-gray-300"
-								>
-									Jina AI
-								</label>
-							</div>
-							<div className="flex items-center gap-2">
-								<input
-									type="radio"
-									id="scraper_firecrawl"
-									name="scraperProvider"
-									value="firecrawl"
-									checked={scraperProvider === "firecrawl"}
-									onChange={(e) =>
-										setScraperProvider(e.target.value as ScraperProvider)
-									}
-									className="scale-125"
-								/>
-								<label
-									htmlFor="scraper_firecrawl"
-									className="text-gray-700 dark:text-gray-300"
-								>
-									Firecrawl
-								</label>
+					{/* Fourth row: Scraper Provider (irrelevant when translating pasted text directly) */}
+					{!directTranslate && (
+						<div className="flex flex-col lg:flex-row lg:items-center gap-3">
+							<span className="text-gray-700 dark:text-gray-300 font-medium text-sm whitespace-nowrap">
+								Scraper:
+							</span>
+							<div className="flex flex-wrap items-center gap-4">
+								<div className="flex items-center gap-2">
+									<input
+										type="radio"
+										id="scraper_jina"
+										name="scraperProvider"
+										value="jina"
+										checked={scraperProvider === "jina"}
+										onChange={(e) =>
+											setScraperProvider(e.target.value as ScraperProvider)
+										}
+										className="scale-125"
+									/>
+									<label
+										htmlFor="scraper_jina"
+										className="text-gray-700 dark:text-gray-300"
+									>
+										Jina AI
+									</label>
+								</div>
+								<div className="flex items-center gap-2">
+									<input
+										type="radio"
+										id="scraper_firecrawl"
+										name="scraperProvider"
+										value="firecrawl"
+										checked={scraperProvider === "firecrawl"}
+										onChange={(e) =>
+											setScraperProvider(e.target.value as ScraperProvider)
+										}
+										className="scale-125"
+									/>
+									<label
+										htmlFor="scraper_firecrawl"
+										className="text-gray-700 dark:text-gray-300"
+									>
+										Firecrawl
+									</label>
+								</div>
 							</div>
 						</div>
-					</div>
+					)}
 				</div>
 
 				<div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-submission of #24 targeting `master`. #24 was merged into the `cursor/direct-translate-mode-2bd9` branch (which had already been merged to `master` via #23), so its change never landed on `master`. This PR cherry-picks that commit onto the latest `master`.

When the **Direct Translate** checkbox is checked, the pasted text goes straight to the LLM and no scraping happens, so the **Scraper** row (Jina AI / Firecrawl) is hidden in that mode. Unchecking Direct Translate brings it back, with the previously selected provider preserved (the `scraperProvider` state is untouched).

## Changes

- `src/pages/_Translate.tsx`: wrapped the Scraper Provider row in a `{!directTranslate && (...)}` conditional.

## Verification

- `npm run lint` and `npm run build` (astro check + build) pass on top of latest `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f97cab03-b1e3-4bd9-9716-1a5fd8242bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f97cab03-b1e3-4bd9-9716-1a5fd8242bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

