### PR TITLE
Require Node 24 or newer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Cursor Cloud specific instructions
 
-This is a single Astro v6 (SSR) + React 19 app — an AI web-novel translator ("AI Convert Translator"). There is only one service to run. Node `>=22.0.0` is required (see `package.json` `engines`).
+This is a single Astro v6 (SSR) + React 19 app — an AI web-novel translator ("AI Convert Translator"). There is only one service to run. Node `>=24.0.0` is required (see `package.json` `engines`).
 
 Standard commands live in `package.json` scripts; use them directly:
 - Dev server: `npm run dev` (Astro dev on `http://localhost:4321`; override port with `PORT`).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"version": "0.0.1",
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=24.0.0"
 	},
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`engines.node` moves from `">=22.0.0"` to `">=24.0.0"`, and the matching sentence in `AGENTS.md` was updated so the two don't drift apart. Those are the only two places in the repo that name a Node version — there are no CI workflows or `.nvmrc` to keep in sync.

I read "24.x" as a Node 24 floor and kept the existing `>=` style rather than pinning to an exact `24.x` range, since `@types/node` is already on 26 and a hard pin would reject newer runtimes. If you did mean to pin exactly, it's a one-value edit.

## Verification

Installed Node 24.18.0 (the current `lts/krypton`) via nvm, wiped `node_modules`, and ran a clean `npm ci` followed by `npm run lint`, `npm run test` (3 tests pass) and `npm run build` (`astro check` reports 0 errors). Nothing in the toolchain objects to Node 24.

Worth knowing for local setup: Node 24 ships npm 11, which withholds install scripts behind an approval gate, so `npm ci` prints a warning that `esbuild`'s `postinstall` did not run. The build is unaffected because the platform binary arrives through the `@esbuild/linux-x64` optional dependency, but the warning is new for anyone upgrading.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8945bd2-53f0-49a0-a754-fd3a2677e850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8945bd2-53f0-49a0-a754-fd3a2677e850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

