### PR TITLE
Disable GPT 5.6 Sol, blocked by provider safety filters

### DIFF
--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -15,14 +15,14 @@ test("nano gpt requests are sent with the configured service tier", async () => 
 	});
 
 	const result = streamText({
-		model: MODEL_MAP["nanogpt|openai/gpt-5.6-sol"],
+		model: MODEL_MAP["nanogpt|zai-org/glm-5.2"],
 		prompt: "hello",
 		providerOptions: { nanoGpt: { service_tier: NANO_GPT_SERVICE_TIER } },
 	});
 	await result.consumeStream();
 
 	expect(bodies[0]).toMatchObject({
-		model: "openai/gpt-5.6-sol",
+		model: "zai-org/glm-5.2",
 		service_tier: "flex",
 	});
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -42,10 +42,12 @@ export const NANO_GPT_MODELS = {
 		submodel: "meta/muse-spark-1.1",
 		label: "Muse Spark 1.1",
 	}),
-	gptSol: nanoGptModel({
-		submodel: "openai/gpt-5.6-sol",
-		label: "GPT 5.6 Sol",
-	}),
+	// Disabled: safety filters reject the chapters we send, so every request
+	// fails with "Your prompt was blocked by safety filters."
+	// gptSol: nanoGptModel({
+	// 	submodel: "openai/gpt-5.6-sol",
+	// 	label: "GPT 5.6 Sol",
+	// }),
 	// Disabled: output quality was too low for translation use.
 	// grok: nanoGptModel({
 	// 	submodel: "x-ai/grok-4.5",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`openai/gpt-5.6-sol` is commented out of `NANO_GPT_MODELS`, following the same pattern as the Mimo and Grok entries, with a note recording that requests come back as "Your prompt was blocked by safety filters." rather than a translation. The option disappears from the model picker without any change to the UI code, since the radio list is generated from that object.

The service-tier test had to move off the disabled model, so it now exercises GLM 5.2 and asserts `model: "zai-org/glm-5.2"` with `service_tier: "flex"`. The flex tier itself is untouched and still applies to every remaining Nano GPT model.

## Verification

`npm run lint`, `npm run test` (3 pass) and `npm run build` (`astro check` reports 0 errors) all pass under Node 24.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8945bd2-53f0-49a0-a754-fd3a2677e850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8945bd2-53f0-49a0-a754-fd3a2677e850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

