### PR TITLE
Add Kimi K3 (Nano GPT) with high reasoning effort

### DIFF
--- a/src/lib/models.test.ts
+++ b/src/lib/models.test.ts
@@ -1,11 +1,13 @@
 import { streamText } from "ai";
 import { expect, test, vi } from "vitest";
 
-import { MODEL_MAP, NANO_GPT_SERVICE_TIER } from "./models";
+import {
+	MODEL_MAP,
+	MODEL_REASONING_EFFORT,
+	NANO_GPT_SERVICE_TIER,
+} from "./models";
 
-test("nano gpt requests are sent with the configured service tier", async () => {
-	const bodies: unknown[] = [];
-
+function stubStreamingFetch(bodies: unknown[]) {
 	vi.stubGlobal("fetch", async (_url: unknown, init: RequestInit) => {
 		bodies.push(JSON.parse(String(init.body)));
 		return new Response(
@@ -13,6 +15,11 @@ test("nano gpt requests are sent with the configured service tier", async () => 
 			{ headers: { "content-type": "text/event-stream" } },
 		);
 	});
+}
+
+test("nano gpt requests are sent with the configured service tier", async () => {
+	const bodies: unknown[] = [];
+	stubStreamingFetch(bodies);
 
 	const result = streamText({
 		model: MODEL_MAP["nanogpt|zai-org/glm-5.2"],
@@ -24,5 +31,28 @@ test("nano gpt requests are sent with the configured service tier", async () => 
 	expect(bodies[0]).toMatchObject({
 		model: "zai-org/glm-5.2",
 		service_tier: "flex",
+	});
+	expect(bodies[0]).not.toHaveProperty("reasoning_effort");
+});
+
+test("kimi k3 asks for high, not maximum, reasoning effort", async () => {
+	const model = "nanogpt|moonshotai/kimi-k3";
+	expect(MODEL_REASONING_EFFORT[model]).toBe("high");
+
+	const bodies: unknown[] = [];
+	stubStreamingFetch(bodies);
+
+	const result = streamText({
+		model: MODEL_MAP[model],
+		prompt: "hello",
+		reasoning: MODEL_REASONING_EFFORT[model],
+		providerOptions: { nanoGpt: { service_tier: NANO_GPT_SERVICE_TIER } },
+	});
+	await result.consumeStream();
+
+	expect(bodies[0]).toMatchObject({
+		model: "moonshotai/kimi-k3",
+		service_tier: "flex",
+		reasoning_effort: "high",
 	});
 });

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -3,17 +3,31 @@ import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
+// Subset of the AI SDK's `reasoning` call setting. Providers translate it into
+// their own knob; Nano GPT sends it as `reasoning_effort`.
+// https://docs.nano-gpt.com/api-reference/miscellaneous/extended-thinking
+export type ReasoningEffort =
+	| "none"
+	| "minimal"
+	| "low"
+	| "medium"
+	| "high"
+	| "xhigh";
+
 function nanoGptModel<const TSubmodel extends string>({
 	submodel,
 	label,
+	reasoningEffort,
 }: {
 	submodel: TSubmodel;
 	label: string;
+	reasoningEffort?: ReasoningEffort;
 }) {
 	return {
 		submodel,
 		modelType: `nanogpt|${submodel}` as `nanogpt|${TSubmodel}`,
 		label,
+		reasoningEffort,
 	};
 }
 
@@ -37,6 +51,13 @@ export const NANO_GPT_MODELS = {
 	geminiFlash: nanoGptModel({
 		submodel: "google/gemini-3.6-flash",
 		label: "Gemini 3.6 Flash",
+	}),
+	kimi: nanoGptModel({
+		submodel: "moonshotai/kimi-k3",
+		label: "Kimi K3",
+		// "xhigh" is the maximum depth and burns far more reasoning tokens than a
+		// chapter translation needs.
+		reasoningEffort: "high",
 	}),
 	museSpark: nanoGptModel({
 		submodel: "meta/muse-spark-1.1",
@@ -121,3 +142,11 @@ export const MODEL_MAX_TOKENS: Partial<Record<ModelType, number>> = {
 	anthropic: 128000,
 	deepseek: 48000,
 };
+
+export const MODEL_REASONING_EFFORT: Partial<
+	Record<ModelType, ReasoningEffort>
+> = Object.fromEntries(
+	Object.values(NANO_GPT_MODELS)
+		.filter((model) => model.reasoningEffort != null)
+		.map(({ modelType, reasoningEffort }) => [modelType, reasoningEffort]),
+);

--- a/src/pages/api/translate.ts
+++ b/src/pages/api/translate.ts
@@ -7,6 +7,7 @@ import {
 	isNanoGptModel,
 	MODEL_MAP,
 	MODEL_MAX_TOKENS,
+	MODEL_REASONING_EFFORT,
 	type ModelType,
 	NANO_GPT_SERVICE_TIER,
 	type ScraperProvider,
@@ -88,6 +89,7 @@ async function getStreamResultFromSource(
 	const result = streamText({
 		model: MODEL_MAP[model],
 		maxOutputTokens: MODEL_MAX_TOKENS[model],
+		reasoning: MODEL_REASONING_EFFORT[model],
 		instructions: PROMPT_MAP[mode],
 		messages: [
 			{
@@ -131,6 +133,7 @@ async function getContinuationStreamResult(
 	const result = streamText({
 		model: MODEL_MAP[model],
 		maxOutputTokens: MODEL_MAX_TOKENS[model],
+		reasoning: MODEL_REASONING_EFFORT[model],
 		instructions: PROMPT_MAP[mode],
 		messages: [
 			{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `moonshotai/kimi-k3` as a Nano GPT model option, listed just before Muse Spark 1.1 in the model picker.

The model runs with reasoning effort `high` rather than `xhigh` (Nano GPT's maximum), so thinking stays bounded for chapter translations.

## How

- `nanoGptModel()` entries can now carry an optional `reasoningEffort`, and `MODEL_REASONING_EFFORT` exposes it per model type alongside the existing `MODEL_MAX_TOKENS` map.
- Both `streamText` calls in `POST /api/translate` pass `reasoning: MODEL_REASONING_EFFORT[model]`. The AI SDK's standardized `reasoning` setting is what the OpenAI-compatible provider turns into `reasoning_effort` in the request body; sending `reasoning_effort` through `providerOptions` does not work, because the provider overwrites that key from its own parsed options.

## Verification

- `moonshotai/kimi-k3` is present in `GET https://nano-gpt.com/api/v1/models`.
- New test asserts a Kimi K3 request body contains `reasoning_effort: "high"` (and that models without a configured effort still send no `reasoning_effort`).
- `npm run test`, `npm run lint`, and `npm run build` all pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc7dcd7-365c-46c8-bba7-10f2f986e110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc7dcd7-365c-46c8-bba7-10f2f986e110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

