### PR TITLE
Keep the translation prompt after clicking Send

### DIFF
--- a/src/pages/_Translate.tsx
+++ b/src/pages/_Translate.tsx
@@ -39,7 +39,6 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 		setCompletion,
 		setInput,
 		handleInputChange,
-		handleSubmit,
 		isLoading,
 	} = useCompletion({
 		api: "/api/translate",
@@ -149,8 +148,14 @@ const Translate: React.FC<{ initialUrl: string }> = ({ initialUrl }) => {
 			<div className="bg-white dark:bg-gray-800 rounded-lg shadow flex flex-col h-full">
 				<form
 					onSubmit={(event) => {
+						event.preventDefault();
+						if (!input) {
+							return;
+						}
 						setContinuedCompletionPrefix("");
-						handleSubmit(event);
+						// handleSubmit() clears `input` as of @ai-sdk/react 4.0.64.
+						// Keep the URL/text so Next/Previous and Continue still work.
+						complete(input);
 					}}
 					className="p-4"
 				>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Send was emptying the URL/text box. That came in with the AI SDK bump in #31: `@ai-sdk/react@4.0.64` changed `useCompletion().handleSubmit` to call `setInput('')` after starting the request.

This app needs the prompt to stay put. Next/Previous chapter and Continue both read `input`.

## Fix

Stop using `handleSubmit`. The form now `preventDefault`s and calls `complete(input)`, which is the same request path without clearing the field.

## Verification

`npm run lint`, `npm run test` (4 pass), and `npm run build` (`astro check` 0 errors) all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d725cb0-910c-49a5-b182-26520de6a0e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d725cb0-910c-49a5-b182-26520de6a0e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

