### PR TITLE
Add Qwen 3.8 Max Thinking as a Nano GPT model option

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -59,6 +59,10 @@ export const NANO_GPT_MODELS = {
 		// chapter translation needs.
 		reasoningEffort: "high",
 	}),
+	qwenMaxThinking: nanoGptModel({
+		submodel: "qwen3.8-max:thinking",
+		label: "Qwen 3.8 Max Thinking",
+	}),
 	museSpark: nanoGptModel({
 		submodel: "meta/muse-spark-1.1",
 		label: "Muse Spark 1.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Qwen 3.8 Max has never been offered in this app. The only Qwen model that ever appeared was `qwen3.7-max:thinking` in commit 66cd09a, which was later replaced and is no longer referenced anywhere.

This adds `qwen3.8-max:thinking` to `NANO_GPT_MODELS`, which is enough to surface it as a radio option in the translate UI and to register it in `MODEL_MAP`, since both are derived from that map. Confirmed the id exists in Nano GPT's `/api/v1/models` listing.

No reasoning effort override is set, so the provider default applies (unlike Kimi K3, which is capped at `high`).

Lint, tests, and `astro check` all pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f094c107-1205-4936-b332-c63242a465b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f094c107-1205-4936-b332-c63242a465b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

