### PR TITLE
Bump Muse Spark to 1.2

### DIFF
--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -64,8 +64,8 @@ export const NANO_GPT_MODELS = {
 		label: "Qwen 3.8 Max Thinking",
 	}),
 	museSpark: nanoGptModel({
-		submodel: "meta/muse-spark-1.1",
-		label: "Muse Spark 1.1",
+		submodel: "meta/muse-spark-1.2",
+		label: "Muse Spark 1.2",
 	}),
 	// Disabled: safety filters reject the chapters we send, so every request
 	// fails with "Your prompt was blocked by safety filters."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the Muse Spark Nano GPT option from `meta/muse-spark-1.1` to `meta/muse-spark-1.2` and updates the UI label to match.

The `museSpark` key is unchanged, so the radio option still maps through `NANO_GPT_MODELS` into `MODEL_MAP` the same way. Confirmed `meta/muse-spark-1.2` is listed by Nano GPT's `/api/v1/models` endpoint.

Lint and tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f094c107-1205-4936-b332-c63242a465b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f094c107-1205-4936-b332-c63242a465b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

